### PR TITLE
Backbone.Model instances can now forego declaring the "mutators" field

### DIFF
--- a/src/backbone.mutators.js
+++ b/src/backbone.mutators.js
@@ -70,6 +70,9 @@
         oldSet      = Backbone.Model.prototype.set,
         oldToJson   = Backbone.Model.prototype.toJSON;
 
+    // This is necessary to ensure that Models declared without the mutators object do not throw and error
+    Mutator.prototype.mutators = {};
+
     // override get functionality to fetch the mutator props
     Mutator.prototype.get = function (attr) {
         var isMutator = this.mutators !== undef;


### PR DESCRIPTION
Made a fix to ensure that Backbone.Model instances without a mutators object would not cause an error to be thrown by Backbone.Mutator with certain versions of the _.each method. 
