### PR TITLE
Using w/ Require AMD - this.mutators is undefined throws Type Error - Line 169

### DIFF
--- a/backbone.mutators.js
+++ b/backbone.mutators.js
@@ -166,6 +166,9 @@ IN THE SOFTWARE.*/
         // fetch ye olde values
         var attr = oldToJson.call(this);
         // iterate over all mutators (if there are some)
+        if ( !this.mutators ) {
+            this.mutators = {};
+        }
         _.each(this.mutators, _.bind(function (mutator, name) {
             // check if we have some getter mutations (nested or )
             if (_.isObject(this.mutators[name]) === true && _.isFunction(this.mutators[name].get)) {


### PR DESCRIPTION
When passing Mutators.js as a dependency on a model that did not have any mutators defined, a type error is thrown. Cannot read property 'forEach' of undefined - Line 169. This caused the entire app to break.

Adding a simple if statement resolved this. I will submit a pull request to help avoid this user error and allow the app to build as normal.
