### PR TITLE
Changed scope during serialization. Fixes #13

### DIFF
--- a/src/backbone.mutators.js
+++ b/src/backbone.mutators.js
@@ -156,9 +156,9 @@
         _.each(this.mutators, _.bind(function (mutator, name) {
             // check if we have some getter mutations (nested or )
             if (_.isObject(this.mutators[name]) === true && _.isFunction(this.mutators[name].get)) {
-                attr[name] = _.bind(this.mutators[name].get, this.attributes)();
+                attr[name] = _.bind(this.mutators[name].get, this)();
             } else {
-                attr[name] = _.bind(this.mutators[name], this.attributes)();
+                attr[name] = _.bind(this.mutators[name], this)();
             }
         }, this));
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -334,7 +334,7 @@ test("can serialize an unmutated model", function () {
 	equal((new Model()).toJSON().b, 'b', 'can serialize unmutated model');	
 });
 
-test("can serialize an unmutated model", function () {
+test("can serialize mutated model", function () {
 	expect(3);
 	var Model = Backbone.Model.extend({
 		defaults: {
@@ -343,13 +343,13 @@ test("can serialize an unmutated model", function () {
 		},
 		mutators: {
 			state: function () {
-				return this.a + ', ' + this.b;
+				return this.get('a') + ', ' + this.get('b');
 			}
 		}
 	});
 
 	equal((new Model()).toJSON().a, 'a', 'can serialize mutated model');
-	equal((new Model()).toJSON().b, 'b', 'can serialize mutated model');	
+	equal((new Model()).get('state'), 'a, b', 'can serialize mutated model');
 	equal((new Model()).toJSON().state, 'a, b', 'can serialize mutated model');		
 });
 


### PR DESCRIPTION
Hello.

This should fix the problem with scope in mutator during `toJSON()` call.
You can take a look at tests to see, how the behavior is changed.
