### PR TITLE
More specific conditional for Node detection

### DIFF
--- a/backbone.mutators.js
+++ b/backbone.mutators.js
@@ -26,7 +26,7 @@ IN THE SOFTWARE.*/
 (function (root, factory, undef) {
     'use strict';
 
-    if (typeof exports === 'object') {
+    if (typeof exports === 'object' && typeof require === 'function') {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like enviroments that support module.exports,
         // like Node.


### PR DESCRIPTION
Hi, I have been using your library with the Thorax Backbone framework, and last week they updated their package structure to include Backbone using Bower. 

Since Thorax has a module 'exports' object but no 'require' function, it would trip the Node conditional on initialize, but fail because the require object doesn't exist. I just made it a little more specific, and it fixed my problem by attaching to the window Backbone object instead of trying to require it in. I hope it jives with you.

Chris
