### PR TITLE
Loosen the restrictions on Underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "grunt-qunit-istanbul": "~0.1.x",
     "grunt-saucelabs": "~4.0.0",
     "qunitjs": "~1.11.x",
-    "underscore": "^1.4.4"
+    "underscore": "^1.8.3"
   },
   "dependencies": {
-    "underscore": "~1.4.x"
+    "underscore": ">= 1.4.x"
   },
   "peerDependencies": {
     "backbone": "~1.x"


### PR DESCRIPTION
Since it's primarily use is a utility library and local tests show that the specs still pass